### PR TITLE
【講義課題24】絞り込み検索（30代のみ、Javaコース）実装

### DIFF
--- a/src/main/java/raisetech/studentmanagement/controller/StudentController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentController.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @RestController
 public class StudentController {
-    private StudentService service;
+    private final StudentService service;
 
     @Autowired
     public StudentController(StudentService service) {

--- a/src/main/java/raisetech/studentmanagement/controller/StudentCoursesController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentCoursesController.java
@@ -1,21 +1,24 @@
 package raisetech.studentmanagement.controller;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import raisetech.studentmanagement.data.StudentsCourses;
-import raisetech.studentmanagement.repository.StudentCoursesRepository;
+import raisetech.studentmanagement.service.StudentService;
 
 import java.util.List;
 
 @RestController
 public class StudentCoursesController {
-    @Autowired
-    private StudentCoursesRepository repository;
+
+    private StudentService service;
+
+    public StudentCoursesController(StudentService service) {
+        this.service = service;
+    }
 
     @GetMapping("/studentsCoursesList")
     public List<StudentsCourses> getStudentCourses() {
-        return repository.search();
+        return service.searchStudentCourses();
 
     }
 }

--- a/src/main/java/raisetech/studentmanagement/controller/StudentCoursesController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentCoursesController.java
@@ -10,7 +10,7 @@ import java.util.List;
 @RestController
 public class StudentCoursesController {
 
-    private StudentService service;
+    private final StudentService service;
 
     public StudentCoursesController(StudentService service) {
         this.service = service;

--- a/src/main/java/raisetech/studentmanagement/repository/StudentCoursesRepository.java
+++ b/src/main/java/raisetech/studentmanagement/repository/StudentCoursesRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 
 @Mapper
 public interface StudentCoursesRepository {
-    @Select("SELECT * FROM students_courses")
+    @Select(" SELECT id, student_id, course_name, start_date, scheduled_end_date FROM students_courses WHERE TRIM(course_name) = 'Javaコース'")
     List<StudentsCourses> search();
 }

--- a/src/main/java/raisetech/studentmanagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/studentmanagement/repository/StudentRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Mapper
 public interface StudentRepository {
 
-    @Select("SELECT * FROM students")
+    @Select("SELECT id, full_name, furigana, nickname, email, region, gender, age FROM students WHERE age BETWEEN 30 AND 39")
     List<Student> search();
 
 

--- a/src/main/java/raisetech/studentmanagement/service/StudentService.java
+++ b/src/main/java/raisetech/studentmanagement/service/StudentService.java
@@ -39,7 +39,7 @@ public class StudentService {
         List<StudentsCourses> allCourses = studentCoursesRepository.search();
         //kadai2絞り込み検索『Javaコース』のコース情報のみ抽出しリストをコントローラーに返す。
         return allCourses.stream()
-                .filter(studentsCourses -> "Javaコース".equals(studentsCourses.getCourseName()))
+                .filter(studentsCourses -> "Javaコース".equals(studentsCourses.getCourseName().trim()))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/raisetech/studentmanagement/service/StudentService.java
+++ b/src/main/java/raisetech/studentmanagement/service/StudentService.java
@@ -14,8 +14,8 @@ import java.util.Optional;
 @Service
 public class StudentService {
 
-    private StudentRepository studentRepository;
-    private StudentCoursesRepository studentCoursesRepository;
+    private final StudentRepository studentRepository;
+    private final StudentCoursesRepository studentCoursesRepository;
 
     @Autowired
     public StudentService(

--- a/src/main/java/raisetech/studentmanagement/service/StudentService.java
+++ b/src/main/java/raisetech/studentmanagement/service/StudentService.java
@@ -10,7 +10,6 @@ import raisetech.studentmanagement.repository.StudentRepository;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 public class StudentService {
@@ -32,10 +31,7 @@ public class StudentService {
                 .orElse(Collections.emptyList());
 
         //kadai 絞り込み検索30代のみ抽出。リストをコントローラーに返す。
-
-        return allStudents.stream()
-                .filter(student -> student.getAge() >= 30 && student.getAge() <= 39)
-                .collect(Collectors.toList());
+        return allStudents;
     }
 
     public List<StudentsCourses> searchStudentCourses() {
@@ -43,11 +39,6 @@ public class StudentService {
         List<StudentsCourses> allCourses = Optional.ofNullable(studentCoursesRepository.search())
                 .orElse(Collections.emptyList());
         //kadai2絞り込み検索『Javaコース』のコース情報のみ抽出しリストをコントローラーに返す。
-        return allCourses.stream()
-                .filter(studentsCourses -> Optional.ofNullable(studentsCourses.getCourseName())
-                        .map(String::trim)
-                        .filter("Javaコース"::equals)
-                        .isPresent())
-                .collect(Collectors.toList());
+        return allCourses;
     }
 }

--- a/src/main/java/raisetech/studentmanagement/service/StudentService.java
+++ b/src/main/java/raisetech/studentmanagement/service/StudentService.java
@@ -8,6 +8,7 @@ import raisetech.studentmanagement.repository.StudentCoursesRepository;
 import raisetech.studentmanagement.repository.StudentRepository;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class StudentService {
@@ -24,14 +25,21 @@ public class StudentService {
     }
 
     public List<Student> searchStudentList() {
-        //ここで何かしらの処理を行う
+        //DBから全学生データ取得
+        List<Student> allStudents = studentRepository.search();
         //kadai 絞り込み検索30代のみ抽出。リストをコントローラーに返す。
-        return studentRepository.search();
+
+        return allStudents.stream()
+                .filter(student -> student.getAge() >= 30 && student.getAge() <= 39)
+                .collect(Collectors.toList());
     }
 
     public List<StudentsCourses> searchStudentCourses() {
-        //ここで何かしらの処理を行う
+        //DBから全コースデータ取得
+        List<StudentsCourses> allCourses = studentCoursesRepository.search();
         //kadai2絞り込み検索『Javaコース』のコース情報のみ抽出しリストをコントローラーに返す。
-        return studentCoursesRepository.search();
+        return allCourses.stream()
+                .filter(studentsCourses -> "Javaコース".equals(studentsCourses.getCourseName()))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/raisetech/studentmanagement/service/StudentService.java
+++ b/src/main/java/raisetech/studentmanagement/service/StudentService.java
@@ -7,7 +7,9 @@ import raisetech.studentmanagement.data.StudentsCourses;
 import raisetech.studentmanagement.repository.StudentCoursesRepository;
 import raisetech.studentmanagement.repository.StudentRepository;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,7 +28,9 @@ public class StudentService {
 
     public List<Student> searchStudentList() {
         //DBから全学生データ取得
-        List<Student> allStudents = studentRepository.search();
+        List<Student> allStudents = Optional.ofNullable(studentRepository.search())
+                .orElse(Collections.emptyList());
+
         //kadai 絞り込み検索30代のみ抽出。リストをコントローラーに返す。
 
         return allStudents.stream()
@@ -36,10 +40,14 @@ public class StudentService {
 
     public List<StudentsCourses> searchStudentCourses() {
         //DBから全コースデータ取得
-        List<StudentsCourses> allCourses = studentCoursesRepository.search();
+        List<StudentsCourses> allCourses = Optional.ofNullable(studentCoursesRepository.search())
+                .orElse(Collections.emptyList());
         //kadai2絞り込み検索『Javaコース』のコース情報のみ抽出しリストをコントローラーに返す。
         return allCourses.stream()
-                .filter(studentsCourses -> "Javaコース".equals(studentsCourses.getCourseName().trim()))
+                .filter(studentsCourses -> Optional.ofNullable(studentsCourses.getCourseName())
+                        .map(String::trim)
+                        .filter("Javaコース"::equals)
+                        .isPresent())
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
実装内容

実装した機能: StudentService に以下の2つの絞り込みロジックを実装しました。
・searchStudentList(): 30代の学生のみを抽出。
・searchStudentCourses(): Javaコース のコース情報のみを抽出。

現在の状況とデバッグ経緯
動作状況
①30代の学生抽出は**正常に動作**しています。
②動作不良→**正常動作**: `Javaコース` の抽出のみ、ロジックを実装しても全データが返ってきてしまい、抽出できない。
【最終原因】
💡試したこと
①環境クリーンアップ：`./gradlew clean`、`build`、`bootRun` を実行し、古いクラスファイルを排除しました。
②DBデータ確認: MySQLのコース名にスペースが混入している可能性があることがわかりました。
③ コード修正: DBのスペース問題に対応するため、`searchStudentCourses` 内に `.trim()` を追加しました。
④最終的に、`StudentCoursesController` が `StudentService` を経由していなかったことが判明。
【最終対応】
構造修正：`StudentCoursesController` を `StudentService` 経由で呼び出すよう修正
動作確認：修正後、全機能が正常に動作でき絞り込み検索も問題なくできました。
<img width="1682" height="134" alt="スクリーンショット 2025-10-31 12 01 19" src="https://github.com/user-attachments/assets/d39ed24b-e00e-41d8-9716-ddd150d19317" />

ご確認お願いいたします。