### PR TITLE
33_Read処理のREST化とPostman実践の課題

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 
 // MyBatis
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
+    //バリデーション
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/raisetech/studentmanagement/controller/StudentApiController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentApiController.java
@@ -11,6 +11,7 @@ import raisetech.studentmanagement.domain.StudentDetail;
 import raisetech.studentmanagement.service.StudentService;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api")
@@ -32,9 +33,14 @@ public class StudentApiController {
         return converter.convertStudentDetails(students, studentsCourses);
     }
 
-    @PutMapping("/students")
-    public ResponseEntity<String> updateStudent(@RequestBody @Valid StudentDetail studentDetail) {
+    @PutMapping("/students/{id}")
+    public ResponseEntity<Map<String, String>> updateStudent(@PathVariable int id,
+                                                             @RequestBody @Valid StudentDetail studentDetail) {
+        studentDetail.getStudent().setId(id);
         service.updateStudent(studentDetail);
-        return ResponseEntity.ok("更新処理が成功しました。");
+
+        Map<String, String> response = new java.util.HashMap<>();
+        response.put("message", "更新処理が成功しました。");
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/raisetech/studentmanagement/controller/StudentApiController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentApiController.java
@@ -7,11 +7,11 @@ import org.springframework.web.bind.annotation.*;
 import raisetech.studentmanagement.controller.converter.StudentConverter;
 import raisetech.studentmanagement.data.Student;
 import raisetech.studentmanagement.data.StudentsCourses;
+import raisetech.studentmanagement.domain.ApiResponse;
 import raisetech.studentmanagement.domain.StudentDetail;
 import raisetech.studentmanagement.service.StudentService;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api")
@@ -34,13 +34,12 @@ public class StudentApiController {
     }
 
     @PutMapping("/students/{id}")
-    public ResponseEntity<Map<String, String>> updateStudent(@PathVariable int id,
-                                                             @RequestBody @Valid StudentDetail studentDetail) {
+    public ResponseEntity<ApiResponse> updateStudent(@PathVariable int id,
+                                                     @RequestBody @Valid StudentDetail studentDetail) {
         studentDetail.getStudent().setId(id);
         service.updateStudent(studentDetail);
 
-        Map<String, String> response = new java.util.HashMap<>();
-        response.put("message", "更新処理が成功しました。");
+        ApiResponse response = new ApiResponse(true, "更新処理が成功しました。", null);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/raisetech/studentmanagement/controller/StudentApiController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentApiController.java
@@ -1,0 +1,39 @@
+package raisetech.studentmanagement.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import raisetech.studentmanagement.controller.converter.StudentConverter;
+import raisetech.studentmanagement.data.Student;
+import raisetech.studentmanagement.data.StudentsCourses;
+import raisetech.studentmanagement.domain.StudentDetail;
+import raisetech.studentmanagement.service.StudentService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api") // ← 先生が言ってた「プレフィックス（前につける文字）」だよ！
+public class StudentApiController {
+    private StudentService service;
+    private StudentConverter converter;
+
+    @Autowired
+    public StudentApiController(StudentService service, StudentConverter converter) {
+        this.service = service;
+        this.converter = converter;
+    }
+
+    @GetMapping("/studentList")
+    public List<StudentDetail> getStudentList() {
+        List<Student> students = service.searchStudentList();
+        List<StudentsCourses> studentsCourses = service.searchStudentCoursesList();
+
+        return converter.convertStudentDetails(students, studentsCourses);
+    }
+
+    @PostMapping("/updateStudent")
+    public ResponseEntity<String> updateStudent(@RequestBody StudentDetail studentDetail) {
+        service.updateStudent(studentDetail);
+        return ResponseEntity.ok("更新処理が成功しました。");
+    }
+}

--- a/src/main/java/raisetech/studentmanagement/controller/StudentApiController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentApiController.java
@@ -1,5 +1,6 @@
 package raisetech.studentmanagement.controller;
 
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,7 +13,7 @@ import raisetech.studentmanagement.service.StudentService;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api") // ← 先生が言ってた「プレフィックス（前につける文字）」だよ！
+@RequestMapping("/api")
 public class StudentApiController {
     private StudentService service;
     private StudentConverter converter;
@@ -23,7 +24,7 @@ public class StudentApiController {
         this.converter = converter;
     }
 
-    @GetMapping("/studentList")
+    @GetMapping("/students")
     public List<StudentDetail> getStudentList() {
         List<Student> students = service.searchStudentList();
         List<StudentsCourses> studentsCourses = service.searchStudentCoursesList();
@@ -31,8 +32,8 @@ public class StudentApiController {
         return converter.convertStudentDetails(students, studentsCourses);
     }
 
-    @PostMapping("/updateStudent")
-    public ResponseEntity<String> updateStudent(@RequestBody StudentDetail studentDetail) {
+    @PutMapping("/students")
+    public ResponseEntity<String> updateStudent(@RequestBody @Valid StudentDetail studentDetail) {
         service.updateStudent(studentDetail);
         return ResponseEntity.ok("更新処理が成功しました。");
     }

--- a/src/main/java/raisetech/studentmanagement/controller/StudentController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentController.java
@@ -1,5 +1,6 @@
 package raisetech.studentmanagement.controller;
 
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -60,5 +61,15 @@ public class StudentController {
         studentDetail.getStudentsCourses().add(new StudentsCourses());
         model.addAttribute("studentDetail", studentDetail);
         return "updateStudent";
+    }
+
+    @PostMapping("/updateStudent")
+    public String updateStudent(@ModelAttribute @Valid StudentDetail studentDetail, BindingResult result, Model model) {
+        // もし入力ミス（バリデーションエラー）があったら、更新せずに編集画面に戻る
+        if (result.hasErrors()) {
+            return "updateStudent";
+        }
+        service.updateStudent(studentDetail);
+        return "redirect:/studentList";
     }
 }

--- a/src/main/java/raisetech/studentmanagement/controller/StudentController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentController.java
@@ -1,12 +1,10 @@
 package raisetech.studentmanagement.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
+import org.springframework.http.ResponseEntity;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.*;
 import raisetech.studentmanagement.controller.converter.StudentConverter;
 import raisetech.studentmanagement.data.Student;
 import raisetech.studentmanagement.data.StudentsCourses;
@@ -15,7 +13,7 @@ import raisetech.studentmanagement.service.StudentService;
 
 import java.util.List;
 
-@Controller
+@RestController
 public class StudentController {
     private StudentService service;
     private StudentConverter converter;
@@ -27,13 +25,11 @@ public class StudentController {
     }
 
     @GetMapping("/studentList")
-    public String getStudentList(Model model) {
-        //リクエストの加工処理、入力チェックとか
+    public List<StudentDetail> getStudentList() {
         List<Student> students = service.searchStudentList();
         List<StudentsCourses> studentsCourses = service.searchStudentCoursesList();
 
-        model.addAttribute("studentList", converter.convertStudentDetails(students, studentsCourses));
-        return "studentList";
+        return converter.convertStudentDetails(students, studentsCourses);
 
     }
 
@@ -68,11 +64,8 @@ public class StudentController {
     }
 
     @PostMapping("/updateStudent")
-    public String updateStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
-        if (result.hasErrors()) {
-            return "updateStudent";
-        }
+    public ResponseEntity<String> updateStudent(@RequestBody StudentDetail studentDetail) {
         service.updateStudent(studentDetail);
-        return "redirect:/studentList";
+        return ResponseEntity.ok("更新処理が成功しました。");
     }
 }

--- a/src/main/java/raisetech/studentmanagement/controller/StudentController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentController.java
@@ -24,6 +24,15 @@ public class StudentController {
         this.converter = converter;
     }
 
+    @GetMapping("/studentList")
+    public String getStudentList(Model model) {
+        java.util.List<Student> students = service.searchStudentList();
+        java.util.List<StudentsCourses> studentsCourses = service.searchStudentCoursesList();
+
+        model.addAttribute("studentList", converter.convertStudentDetails(students, studentsCourses));
+        return "studentList"; // studentList.html を表示する
+    }
+
     @GetMapping("/newStudent")
     public String newStudent(Model model) {
         StudentDetail studentDetail = new StudentDetail();

--- a/src/main/java/raisetech/studentmanagement/controller/StudentController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentController.java
@@ -1,19 +1,19 @@
 package raisetech.studentmanagement.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import raisetech.studentmanagement.controller.converter.StudentConverter;
 import raisetech.studentmanagement.data.Student;
 import raisetech.studentmanagement.data.StudentsCourses;
 import raisetech.studentmanagement.domain.StudentDetail;
 import raisetech.studentmanagement.service.StudentService;
 
-import java.util.List;
-
-@RestController
+@Controller
 public class StudentController {
     private StudentService service;
     private StudentConverter converter;
@@ -22,15 +22,6 @@ public class StudentController {
     public StudentController(StudentService service, StudentConverter converter) {
         this.service = service;
         this.converter = converter;
-    }
-
-    @GetMapping("/studentList")
-    public List<StudentDetail> getStudentList() {
-        List<Student> students = service.searchStudentList();
-        List<StudentsCourses> studentsCourses = service.searchStudentCoursesList();
-
-        return converter.convertStudentDetails(students, studentsCourses);
-
     }
 
     @GetMapping("/newStudent")
@@ -56,16 +47,9 @@ public class StudentController {
 
     @GetMapping("/updateStudent")
     public String updateStudent(Student student, Model model) {
-
         StudentDetail studentDetail = service.searchStudent(student.getId());
         studentDetail.getStudentsCourses().add(new StudentsCourses());
         model.addAttribute("studentDetail", studentDetail);
         return "updateStudent";
-    }
-
-    @PostMapping("/updateStudent")
-    public ResponseEntity<String> updateStudent(@RequestBody StudentDetail studentDetail) {
-        service.updateStudent(studentDetail);
-        return ResponseEntity.ok("更新処理が成功しました。");
     }
 }

--- a/src/main/java/raisetech/studentmanagement/controller/StudentExceptionHandler.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentExceptionHandler.java
@@ -1,0 +1,25 @@
+package raisetech.studentmanagement.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice // ← 「エラーが起きたら僕の出番だよ！」という呪文
+public class StudentExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class) // ← バリデーションエラーを捕まえる
+    public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+
+        // 「どの項目」が「どうダメだったか」を全部集める
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+                errors.put(error.getField(), error.getDefaultMessage())
+        );
+
+        return ResponseEntity.badRequest().body(errors); // きれいなJSONでお返事！
+    }
+}

--- a/src/main/java/raisetech/studentmanagement/controller/StudentExceptionHandler.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentExceptionHandler.java
@@ -2,24 +2,26 @@ package raisetech.studentmanagement.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import raisetech.studentmanagement.domain.ApiResponse;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@ControllerAdvice // ← 「エラーが起きたら僕の出番だよ！」という呪文
+@RestControllerAdvice(assignableTypes = {StudentApiController.class})
 public class StudentExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class) // ← バリデーションエラーを捕まえる
-    public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+    public ResponseEntity<ApiResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
         Map<String, String> errors = new HashMap<>();
 
         // 「どの項目」が「どうダメだったか」を全部集める
         ex.getBindingResult().getFieldErrors().forEach(error ->
                 errors.put(error.getField(), error.getDefaultMessage())
         );
+        ApiResponse response = new ApiResponse(false, "エラーが発生しました", errors);
 
-        return ResponseEntity.badRequest().body(errors); // きれいなJSONでお返事！
+        return ResponseEntity.badRequest().body(response); // きれいなJSONでお返事！
     }
 }

--- a/src/main/java/raisetech/studentmanagement/data/Student.java
+++ b/src/main/java/raisetech/studentmanagement/data/Student.java
@@ -1,5 +1,6 @@
 package raisetech.studentmanagement.data;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,7 +10,9 @@ import lombok.Setter;
 public class Student {
 
     private int id;
+    @NotBlank(message = "名前を入力してください")
     private String fullName;
+    @NotBlank(message = "フリガナを入力してください")
     private String furigana;
     private String nickName;
     private String email;

--- a/src/main/java/raisetech/studentmanagement/domain/ApiResponse.java
+++ b/src/main/java/raisetech/studentmanagement/domain/ApiResponse.java
@@ -1,0 +1,12 @@
+package raisetech.studentmanagement.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse {
+    private boolean success;
+    private String message;
+    private Object data;
+}

--- a/src/main/java/raisetech/studentmanagement/domain/StudentDetail.java
+++ b/src/main/java/raisetech/studentmanagement/domain/StudentDetail.java
@@ -1,5 +1,6 @@
 package raisetech.studentmanagement.domain;
 
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,8 +14,10 @@ import java.util.List;
 @Setter
 @NoArgsConstructor//からっぽの箱も作れるように
 @AllArgsConstructor//中身を全部詰めた箱も作れるように
+
 public class StudentDetail {
 
+    @Valid
     private Student student;
     private List<StudentsCourses> studentsCourses;
 


### PR DESCRIPTION
## 概要
Postmanで操作可能なREST API形式へ変更しました。

## 変更内容
- StudentControllerに `@RestController` を導入し、JSONを返すように変更。
- 学生更新処理（/updateStudent）で `@RequestBody` を使用し、PostmanからのJSONデータを受け取れるよう実装。
- `ResponseEntity<String>` を使用して、処理成功時に適切なメッセージを返すように修正。

## 動作確認結果
- PostmanからGETリクエストを送り、学生一覧のJSONが取得できることを確認。
- PostmanからPOSTリクエスト（JSON形式）を送り、特定の学生のデータ（フリガナ等）が正常に更新されることを確認。（更新内容：ササキマユカ→マユカササキ）
<img width="1178" height="455" alt="スクリーンショット 2026-02-25 0 29 26" src="https://github.com/user-attachments/assets/96862180-47c6-4dd2-9f45-7d8eb2a37c04" />

- MySQLにて、更新リクエスト後のデータが正しく書き換わっていることを確認済み。